### PR TITLE
Client now detects disconnects and retries

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -11,6 +11,11 @@
 			"Rev": "b673bf363d3658506891150a6dca42059572d1b0"
 		},
 		{
+			"ImportPath": "github.com/cenkalti/backoff",
+			"Comment": "v1.0.0",
+			"Rev": "32cd0c5b3aef12c76ed64aaf678f6c79736be7dc"
+		},
+		{
 			"ImportPath": "github.com/facebookgo/clock",
 			"Rev": "600d898af40aa09a7a93ecb9265d87b0504b6f03"
 		},

--- a/Godeps/_workspace/src/github.com/cenkalti/backoff/.gitignore
+++ b/Godeps/_workspace/src/github.com/cenkalti/backoff/.gitignore
@@ -1,0 +1,22 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe

--- a/Godeps/_workspace/src/github.com/cenkalti/backoff/.travis.yml
+++ b/Godeps/_workspace/src/github.com/cenkalti/backoff/.travis.yml
@@ -1,0 +1,2 @@
+language: go
+go: 1.3.3

--- a/Godeps/_workspace/src/github.com/cenkalti/backoff/LICENSE
+++ b/Godeps/_workspace/src/github.com/cenkalti/backoff/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Cenk Altı
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Godeps/_workspace/src/github.com/cenkalti/backoff/README.md
+++ b/Godeps/_workspace/src/github.com/cenkalti/backoff/README.md
@@ -1,0 +1,116 @@
+# Exponential Backoff [![GoDoc][godoc image]][godoc] [![Build Status][travis image]][travis]
+
+This is a Go port of the exponential backoff algorithm from [Google's HTTP Client Library for Java][google-http-java-client].
+
+[Exponential backoff][exponential backoff wiki]
+is an algorithm that uses feedback to multiplicatively decrease the rate of some process,
+in order to gradually find an acceptable rate.
+The retries exponentially increase and stop increasing when a certain threshold is met.
+
+## How To
+
+We define two functions, `Retry()` and `RetryNotify()`.
+They receive an `Operation` to execute, a `BackOff` algorithm,
+and an optional `Notify` error handler.
+
+The operation will be executed, and will be retried on failure with delay
+as given by the backoff algorithm. The backoff algorithm can also decide when to stop
+retrying.
+In addition, the notify error handler will be called after each failed attempt,
+except for the last time, whose error should be handled by the caller.
+
+```go
+// An Operation is executing by Retry() or RetryNotify().
+// The operation will be retried using a backoff policy if it returns an error.
+type Operation func() error
+
+// Notify is a notify-on-error function. It receives an operation error and
+// backoff delay if the operation failed (with an error).
+//
+// NOTE that if the backoff policy stated to stop retrying,
+// the notify function isn't called.
+type Notify func(error, time.Duration)
+
+func Retry(Operation, BackOff) error
+func RetryNotify(Operation, BackOff, Notify)
+```
+
+## Examples
+
+See more advanced examples in the [godoc][advanced example].
+
+### Retry
+
+Simple retry helper that uses the default exponential backoff algorithm:
+
+```go
+operation := func() error {
+    // An operation that might fail.
+    return nil // or return errors.New("some error")
+}
+
+err := Retry(operation, NewExponentialBackOff())
+if err != nil {
+    // Handle error.
+    return err
+}
+
+// Operation is successful.
+return nil
+```
+
+### Ticker
+
+```go
+operation := func() error {
+    // An operation that might fail
+    return nil // or return errors.New("some error")
+}
+
+b := NewExponentialBackOff()
+ticker := NewTicker(b)
+
+var err error
+
+// Ticks will continue to arrive when the previous operation is still running,
+// so operations that take a while to fail could run in quick succession.
+for range ticker.C {
+    if err = operation(); err != nil {
+        log.Println(err, "will retry...")
+        continue
+    }
+
+    ticker.Stop()
+    break
+}
+
+if err != nil {
+    // Operation has failed.
+    return err
+}
+
+// Operation is successful.
+return nil
+```
+
+## Getting Started
+
+```bash
+# install
+$ go get github.com/cenkalti/backoff
+
+# test
+$ cd $GOPATH/src/github.com/cenkalti/backoff
+$ go get -t ./...
+$ go test -v -cover
+```
+
+[godoc]: https://godoc.org/github.com/cenkalti/backoff
+[godoc image]: https://godoc.org/github.com/cenkalti/backoff?status.png
+[travis]: https://travis-ci.org/cenkalti/backoff
+[travis image]: https://travis-ci.org/cenkalti/backoff.png
+
+[google-http-java-client]: https://github.com/google/google-http-java-client
+[exponential backoff wiki]: http://en.wikipedia.org/wiki/Exponential_backoff
+
+[advanced example]: https://godoc.org/github.com/cenkalti/backoff#example_

--- a/Godeps/_workspace/src/github.com/cenkalti/backoff/backoff.go
+++ b/Godeps/_workspace/src/github.com/cenkalti/backoff/backoff.go
@@ -1,0 +1,59 @@
+// Package backoff implements backoff algorithms for retrying operations.
+//
+// Also has a Retry() helper for retrying operations that may fail.
+package backoff
+
+import "time"
+
+// BackOff is a backoff policy for retrying an operation.
+type BackOff interface {
+	// NextBackOff returns the duration to wait before retrying the operation,
+	// or backoff.Stop to indicate that no more retries should be made.
+	//
+	// Example usage:
+	//
+	// 	duration := backoff.NextBackOff();
+	// 	if (duration == backoff.Stop) {
+	// 		// Do not retry operation.
+	// 	} else {
+	// 		// Sleep for duration and retry operation.
+	// 	}
+	//
+	NextBackOff() time.Duration
+
+	// Reset to initial state.
+	Reset()
+}
+
+// Indicates that no more retries should be made for use in NextBackOff().
+const Stop time.Duration = -1
+
+// ZeroBackOff is a fixed backoff policy whose backoff time is always zero,
+// meaning that the operation is retried immediately without waiting, indefinitely.
+type ZeroBackOff struct{}
+
+func (b *ZeroBackOff) Reset() {}
+
+func (b *ZeroBackOff) NextBackOff() time.Duration { return 0 }
+
+// StopBackOff is a fixed backoff policy that always returns backoff.Stop for
+// NextBackOff(), meaning that the operation should never be retried.
+type StopBackOff struct{}
+
+func (b *StopBackOff) Reset() {}
+
+func (b *StopBackOff) NextBackOff() time.Duration { return Stop }
+
+// ConstantBackOff is a backoff policy that always returns the same backoff delay.
+// This is in contrast to an exponential backoff policy,
+// which returns a delay that grows longer as you call NextBackOff() over and over again.
+type ConstantBackOff struct {
+	Interval time.Duration
+}
+
+func (b *ConstantBackOff) Reset()                     {}
+func (b *ConstantBackOff) NextBackOff() time.Duration { return b.Interval }
+
+func NewConstantBackOff(d time.Duration) *ConstantBackOff {
+	return &ConstantBackOff{Interval: d}
+}

--- a/Godeps/_workspace/src/github.com/cenkalti/backoff/backoff_test.go
+++ b/Godeps/_workspace/src/github.com/cenkalti/backoff/backoff_test.go
@@ -1,0 +1,27 @@
+package backoff
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNextBackOffMillis(t *testing.T) {
+	subtestNextBackOff(t, 0, new(ZeroBackOff))
+	subtestNextBackOff(t, Stop, new(StopBackOff))
+}
+
+func subtestNextBackOff(t *testing.T, expectedValue time.Duration, backOffPolicy BackOff) {
+	for i := 0; i < 10; i++ {
+		next := backOffPolicy.NextBackOff()
+		if next != expectedValue {
+			t.Errorf("got: %d expected: %d", next, expectedValue)
+		}
+	}
+}
+
+func TestConstantBackOff(t *testing.T) {
+	backoff := NewConstantBackOff(time.Second)
+	if backoff.NextBackOff() != time.Second {
+		t.Error("invalid interval")
+	}
+}

--- a/Godeps/_workspace/src/github.com/cenkalti/backoff/example_test.go
+++ b/Godeps/_workspace/src/github.com/cenkalti/backoff/example_test.go
@@ -1,0 +1,51 @@
+package backoff
+
+import "log"
+
+func ExampleRetry() error {
+	operation := func() error {
+		// An operation that might fail.
+		return nil // or return errors.New("some error")
+	}
+
+	err := Retry(operation, NewExponentialBackOff())
+	if err != nil {
+		// Handle error.
+		return err
+	}
+
+	// Operation is successful.
+	return nil
+}
+
+func ExampleTicker() error {
+	operation := func() error {
+		// An operation that might fail
+		return nil // or return errors.New("some error")
+	}
+
+	b := NewExponentialBackOff()
+	ticker := NewTicker(b)
+
+	var err error
+
+	// Ticks will continue to arrive when the previous operation is still running,
+	// so operations that take a while to fail could run in quick succession.
+	for _ = range ticker.C {
+		if err = operation(); err != nil {
+			log.Println(err, "will retry...")
+			continue
+		}
+
+		ticker.Stop()
+		break
+	}
+
+	if err != nil {
+		// Operation has failed.
+		return err
+	}
+
+	// Operation is successful.
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/cenkalti/backoff/exponential.go
+++ b/Godeps/_workspace/src/github.com/cenkalti/backoff/exponential.go
@@ -1,0 +1,156 @@
+package backoff
+
+import (
+	"math/rand"
+	"time"
+)
+
+/*
+ExponentialBackOff is a backoff implementation that increases the backoff
+period for each retry attempt using a randomization function that grows exponentially.
+
+NextBackOff() is calculated using the following formula:
+
+ randomized interval =
+     RetryInterval * (random value in range [1 - RandomizationFactor, 1 + RandomizationFactor])
+
+In other words NextBackOff() will range between the randomization factor
+percentage below and above the retry interval.
+
+For example, given the following parameters:
+
+ RetryInterval = 2
+ RandomizationFactor = 0.5
+ Multiplier = 2
+
+the actual backoff period used in the next retry attempt will range between 1 and 3 seconds,
+multiplied by the exponential, that is, between 2 and 6 seconds.
+
+Note: MaxInterval caps the RetryInterval and not the randomized interval.
+
+If the time elapsed since an ExponentialBackOff instance is created goes past the
+MaxElapsedTime, then the method NextBackOff() starts returning backoff.Stop.
+
+The elapsed time can be reset by calling Reset().
+
+Example: Given the following default arguments, for 10 tries the sequence will be,
+and assuming we go over the MaxElapsedTime on the 10th try:
+
+ Request #  RetryInterval (seconds)  Randomized Interval (seconds)
+
+  1          0.5                     [0.25,   0.75]
+  2          0.75                    [0.375,  1.125]
+  3          1.125                   [0.562,  1.687]
+  4          1.687                   [0.8435, 2.53]
+  5          2.53                    [1.265,  3.795]
+  6          3.795                   [1.897,  5.692]
+  7          5.692                   [2.846,  8.538]
+  8          8.538                   [4.269, 12.807]
+  9         12.807                   [6.403, 19.210]
+ 10         19.210                   backoff.Stop
+
+Note: Implementation is not thread-safe.
+*/
+type ExponentialBackOff struct {
+	InitialInterval     time.Duration
+	RandomizationFactor float64
+	Multiplier          float64
+	MaxInterval         time.Duration
+	// After MaxElapsedTime the ExponentialBackOff stops.
+	// It never stops if MaxElapsedTime == 0.
+	MaxElapsedTime time.Duration
+	Clock          Clock
+
+	currentInterval time.Duration
+	startTime       time.Time
+}
+
+// Clock is an interface that returns current time for BackOff.
+type Clock interface {
+	Now() time.Time
+}
+
+// Default values for ExponentialBackOff.
+const (
+	DefaultInitialInterval     = 500 * time.Millisecond
+	DefaultRandomizationFactor = 0.5
+	DefaultMultiplier          = 1.5
+	DefaultMaxInterval         = 60 * time.Second
+	DefaultMaxElapsedTime      = 15 * time.Minute
+)
+
+// NewExponentialBackOff creates an instance of ExponentialBackOff using default values.
+func NewExponentialBackOff() *ExponentialBackOff {
+	b := &ExponentialBackOff{
+		InitialInterval:     DefaultInitialInterval,
+		RandomizationFactor: DefaultRandomizationFactor,
+		Multiplier:          DefaultMultiplier,
+		MaxInterval:         DefaultMaxInterval,
+		MaxElapsedTime:      DefaultMaxElapsedTime,
+		Clock:               SystemClock,
+	}
+	if b.RandomizationFactor < 0 {
+		b.RandomizationFactor = 0
+	} else if b.RandomizationFactor > 1 {
+		b.RandomizationFactor = 1
+	}
+	b.Reset()
+	return b
+}
+
+type systemClock struct{}
+
+func (t systemClock) Now() time.Time {
+	return time.Now()
+}
+
+// SystemClock implements Clock interface that uses time.Now().
+var SystemClock = systemClock{}
+
+// Reset the interval back to the initial retry interval and restarts the timer.
+func (b *ExponentialBackOff) Reset() {
+	b.currentInterval = b.InitialInterval
+	b.startTime = b.Clock.Now()
+}
+
+// NextBackOff calculates the next backoff interval using the formula:
+// 	Randomized interval = RetryInterval +/- (RandomizationFactor * RetryInterval)
+func (b *ExponentialBackOff) NextBackOff() time.Duration {
+	// Make sure we have not gone over the maximum elapsed time.
+	if b.MaxElapsedTime != 0 && b.GetElapsedTime() > b.MaxElapsedTime {
+		return Stop
+	}
+	defer b.incrementCurrentInterval()
+	return getRandomValueFromInterval(b.RandomizationFactor, rand.Float64(), b.currentInterval)
+}
+
+// GetElapsedTime returns the elapsed time since an ExponentialBackOff instance
+// is created and is reset when Reset() is called.
+//
+// The elapsed time is computed using time.Now().UnixNano().
+func (b *ExponentialBackOff) GetElapsedTime() time.Duration {
+	return b.Clock.Now().Sub(b.startTime)
+}
+
+// Increments the current interval by multiplying it with the multiplier.
+func (b *ExponentialBackOff) incrementCurrentInterval() {
+	// Check for overflow, if overflow is detected set the current interval to the max interval.
+	if float64(b.currentInterval) >= float64(b.MaxInterval)/b.Multiplier {
+		b.currentInterval = b.MaxInterval
+	} else {
+		b.currentInterval = time.Duration(float64(b.currentInterval) * b.Multiplier)
+	}
+}
+
+// Returns a random value from the following interval:
+// 	[randomizationFactor * currentInterval, randomizationFactor * currentInterval].
+func getRandomValueFromInterval(randomizationFactor, random float64, currentInterval time.Duration) time.Duration {
+	var delta = randomizationFactor * float64(currentInterval)
+	var minInterval = float64(currentInterval) - delta
+	var maxInterval = float64(currentInterval) + delta
+
+	// Get a random value from the range [minInterval, maxInterval].
+	// The formula used below has a +1 because if the minInterval is 1 and the maxInterval is 3 then
+	// we want a 33% chance for selecting either 1, 2 or 3.
+	return time.Duration(minInterval + (random * (maxInterval - minInterval + 1)))
+}

--- a/Godeps/_workspace/src/github.com/cenkalti/backoff/exponential_test.go
+++ b/Godeps/_workspace/src/github.com/cenkalti/backoff/exponential_test.go
@@ -1,0 +1,108 @@
+package backoff
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestBackOff(t *testing.T) {
+	var (
+		testInitialInterval     = 500 * time.Millisecond
+		testRandomizationFactor = 0.1
+		testMultiplier          = 2.0
+		testMaxInterval         = 5 * time.Second
+		testMaxElapsedTime      = 15 * time.Minute
+	)
+
+	exp := NewExponentialBackOff()
+	exp.InitialInterval = testInitialInterval
+	exp.RandomizationFactor = testRandomizationFactor
+	exp.Multiplier = testMultiplier
+	exp.MaxInterval = testMaxInterval
+	exp.MaxElapsedTime = testMaxElapsedTime
+	exp.Reset()
+
+	var expectedResults = []time.Duration{500, 1000, 2000, 4000, 5000, 5000, 5000, 5000, 5000, 5000}
+	for i, d := range expectedResults {
+		expectedResults[i] = d * time.Millisecond
+	}
+
+	for _, expected := range expectedResults {
+		assertEquals(t, expected, exp.currentInterval)
+		// Assert that the next backoff falls in the expected range.
+		var minInterval = expected - time.Duration(testRandomizationFactor*float64(expected))
+		var maxInterval = expected + time.Duration(testRandomizationFactor*float64(expected))
+		var actualInterval = exp.NextBackOff()
+		if !(minInterval <= actualInterval && actualInterval <= maxInterval) {
+			t.Error("error")
+		}
+	}
+}
+
+func TestGetRandomizedInterval(t *testing.T) {
+	// 33% chance of being 1.
+	assertEquals(t, 1, getRandomValueFromInterval(0.5, 0, 2))
+	assertEquals(t, 1, getRandomValueFromInterval(0.5, 0.33, 2))
+	// 33% chance of being 2.
+	assertEquals(t, 2, getRandomValueFromInterval(0.5, 0.34, 2))
+	assertEquals(t, 2, getRandomValueFromInterval(0.5, 0.66, 2))
+	// 33% chance of being 3.
+	assertEquals(t, 3, getRandomValueFromInterval(0.5, 0.67, 2))
+	assertEquals(t, 3, getRandomValueFromInterval(0.5, 0.99, 2))
+}
+
+type TestClock struct {
+	i     time.Duration
+	start time.Time
+}
+
+func (c *TestClock) Now() time.Time {
+	t := c.start.Add(c.i)
+	c.i += time.Second
+	return t
+}
+
+func TestGetElapsedTime(t *testing.T) {
+	var exp = NewExponentialBackOff()
+	exp.Clock = &TestClock{}
+	exp.Reset()
+
+	var elapsedTime = exp.GetElapsedTime()
+	if elapsedTime != time.Second {
+		t.Errorf("elapsedTime=%d", elapsedTime)
+	}
+}
+
+func TestMaxElapsedTime(t *testing.T) {
+	var exp = NewExponentialBackOff()
+	exp.Clock = &TestClock{start: time.Time{}.Add(10000 * time.Second)}
+	// Change the currentElapsedTime to be 0 ensuring that the elapsed time will be greater
+	// than the max elapsed time.
+	exp.startTime = time.Time{}
+	assertEquals(t, Stop, exp.NextBackOff())
+}
+
+func TestBackOffOverflow(t *testing.T) {
+	var (
+		testInitialInterval time.Duration = math.MaxInt64 / 2
+		testMaxInterval     time.Duration = math.MaxInt64
+		testMultiplier                    = 2.1
+	)
+
+	exp := NewExponentialBackOff()
+	exp.InitialInterval = testInitialInterval
+	exp.Multiplier = testMultiplier
+	exp.MaxInterval = testMaxInterval
+	exp.Reset()
+
+	exp.NextBackOff()
+	// Assert that when an overflow is possible the current varerval   time.Duration    is set to the max varerval   time.Duration   .
+	assertEquals(t, testMaxInterval, exp.currentInterval)
+}
+
+func assertEquals(t *testing.T, expected, value time.Duration) {
+	if expected != value {
+		t.Errorf("got: %d, expected: %d", value, expected)
+	}
+}

--- a/Godeps/_workspace/src/github.com/cenkalti/backoff/retry.go
+++ b/Godeps/_workspace/src/github.com/cenkalti/backoff/retry.go
@@ -1,0 +1,46 @@
+package backoff
+
+import "time"
+
+// An Operation is executing by Retry() or RetryNotify().
+// The operation will be retried using a backoff policy if it returns an error.
+type Operation func() error
+
+// Notify is a notify-on-error function. It receives an operation error and
+// backoff delay if the operation failed (with an error).
+//
+// NOTE that if the backoff policy stated to stop retrying,
+// the notify function isn't called.
+type Notify func(error, time.Duration)
+
+// Retry the function f until it does not return error or BackOff stops.
+// f is guaranteed to be run at least once.
+// It is the caller's responsibility to reset b after Retry returns.
+//
+// Retry sleeps the goroutine for the duration returned by BackOff after a
+// failed operation returns.
+func Retry(o Operation, b BackOff) error { return RetryNotify(o, b, nil) }
+
+// RetryNotify calls notify function with the error and wait duration
+// for each failed attempt before sleep.
+func RetryNotify(operation Operation, b BackOff, notify Notify) error {
+	var err error
+	var next time.Duration
+
+	b.Reset()
+	for {
+		if err = operation(); err == nil {
+			return nil
+		}
+
+		if next = b.NextBackOff(); next == Stop {
+			return err
+		}
+
+		if notify != nil {
+			notify(err, next)
+		}
+
+		time.Sleep(next)
+	}
+}

--- a/Godeps/_workspace/src/github.com/cenkalti/backoff/retry_test.go
+++ b/Godeps/_workspace/src/github.com/cenkalti/backoff/retry_test.go
@@ -1,0 +1,34 @@
+package backoff
+
+import (
+	"errors"
+	"log"
+	"testing"
+)
+
+func TestRetry(t *testing.T) {
+	const successOn = 3
+	var i = 0
+
+	// This function is successfull on "successOn" calls.
+	f := func() error {
+		i++
+		log.Printf("function is called %d. time\n", i)
+
+		if i == successOn {
+			log.Println("OK")
+			return nil
+		}
+
+		log.Println("error")
+		return errors.New("error")
+	}
+
+	err := Retry(f, NewExponentialBackOff())
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if i != successOn {
+		t.Errorf("invalid number of retries: %d", i)
+	}
+}

--- a/Godeps/_workspace/src/github.com/cenkalti/backoff/ticker.go
+++ b/Godeps/_workspace/src/github.com/cenkalti/backoff/ticker.go
@@ -1,0 +1,79 @@
+package backoff
+
+import (
+	"runtime"
+	"sync"
+	"time"
+)
+
+// Ticker holds a channel that delivers `ticks' of a clock at times reported by a BackOff.
+//
+// Ticks will continue to arrive when the previous operation is still running,
+// so operations that take a while to fail could run in quick succession.
+type Ticker struct {
+	C        <-chan time.Time
+	c        chan time.Time
+	b        BackOff
+	stop     chan struct{}
+	stopOnce sync.Once
+}
+
+// NewTicker returns a new Ticker containing a channel that will send the time at times
+// specified by the BackOff argument. Ticker is guaranteed to tick at least once.
+// The channel is closed when Stop method is called or BackOff stops.
+func NewTicker(b BackOff) *Ticker {
+	c := make(chan time.Time)
+	t := &Ticker{
+		C:    c,
+		c:    c,
+		b:    b,
+		stop: make(chan struct{}),
+	}
+	go t.run()
+	runtime.SetFinalizer(t, (*Ticker).Stop)
+	return t
+}
+
+// Stop turns off a ticker. After Stop, no more ticks will be sent.
+func (t *Ticker) Stop() {
+	t.stopOnce.Do(func() { close(t.stop) })
+}
+
+func (t *Ticker) run() {
+	c := t.c
+	defer close(c)
+	t.b.Reset()
+
+	// Ticker is guaranteed to tick at least once.
+	afterC := t.send(time.Now())
+
+	for {
+		if afterC == nil {
+			return
+		}
+
+		select {
+		case tick := <-afterC:
+			afterC = t.send(tick)
+		case <-t.stop:
+			t.c = nil // Prevent future ticks from being sent to the channel.
+			return
+		}
+	}
+}
+
+func (t *Ticker) send(tick time.Time) <-chan time.Time {
+	select {
+	case t.c <- tick:
+	case <-t.stop:
+		return nil
+	}
+
+	next := t.b.NextBackOff()
+	if next == Stop {
+		t.Stop()
+		return nil
+	}
+
+	return time.After(next)
+}

--- a/Godeps/_workspace/src/github.com/cenkalti/backoff/ticker_test.go
+++ b/Godeps/_workspace/src/github.com/cenkalti/backoff/ticker_test.go
@@ -1,0 +1,45 @@
+package backoff
+
+import (
+	"errors"
+	"log"
+	"testing"
+)
+
+func TestTicker(t *testing.T) {
+	const successOn = 3
+	var i = 0
+
+	// This function is successfull on "successOn" calls.
+	f := func() error {
+		i++
+		log.Printf("function is called %d. time\n", i)
+
+		if i == successOn {
+			log.Println("OK")
+			return nil
+		}
+
+		log.Println("error")
+		return errors.New("error")
+	}
+
+	b := NewExponentialBackOff()
+	ticker := NewTicker(b)
+
+	var err error
+	for _ = range ticker.C {
+		if err = f(); err != nil {
+			t.Log(err)
+			continue
+		}
+
+		break
+	}
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if i != successOn {
+		t.Errorf("invalid number of retries: %d", i)
+	}
+}

--- a/slack/client.go
+++ b/slack/client.go
@@ -185,14 +185,7 @@ func (c *Client) Start() error {
 	}
 
 	// This serves no real purpose other than to let tests know that a certain client has been initialized
-	val := c.redisClient.HSet(os.Getenv("RELAX_MUTEX_KEY"), fmt.Sprintf("bot-%s-started", c.TeamId), fmt.Sprintf("%d", time.Now().Nanosecond()))
-	if val == nil || val.Val() != true {
-		log.WithFields(log.Fields{
-			"team":  c.TeamId,
-			"error": fmt.Sprintf("could not set bot-%s-started in RELAX_MUTEX_KEY", c.TeamId),
-		}).Error("starting slack client")
-	}
-
+	c.redisClient.HSet(os.Getenv("RELAX_MUTEX_KEY"), fmt.Sprintf("bot-%s-started", c.TeamId), fmt.Sprintf("%d", time.Now().Nanosecond()))
 	Clients[c.TeamId] = c
 
 	return nil

--- a/slack/client.go
+++ b/slack/client.go
@@ -239,10 +239,6 @@ func (c *Client) startPingPump() {
 				break
 			}
 			c.conn.WriteMessage(websocket.TextMessage, []byte(json))
-
-			log.WithFields(log.Fields{
-				"heartbeats": c.heartBeatsMissed,
-			}).Debug("heartbeats missed")
 		}
 	}
 
@@ -494,9 +490,6 @@ func (c *Client) handleMessage(msg *Message) {
 	case "pong":
 		if msg.ReplyTo == c.TeamId {
 			c.ResetHeartBeatsMissed()
-			log.WithFields(log.Fields{
-				"heartbeats": c.heartBeatsMissed,
-			}).Debug("set heartbeats to zero")
 		}
 	case "message":
 		userId := msg.UserId()

--- a/slack/client.go
+++ b/slack/client.go
@@ -10,9 +10,11 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	log "github.com/zerobotlabs/relax/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	"github.com/zerobotlabs/relax/Godeps/_workspace/src/github.com/cenkalti/backoff"
 	"github.com/zerobotlabs/relax/redisclient"
 	"github.com/zerobotlabs/relax/utils"
 
@@ -42,6 +44,7 @@ func NewClient(initJSON string) (*Client, error) {
 		return &c, err
 	}
 
+	c.heartBeatsMutex = &sync.Mutex{}
 	return &c, nil
 }
 
@@ -74,6 +77,18 @@ func InitClients() {
 	}
 
 	go startReadFromRedisPubSubLoop()
+}
+
+func (c *Client) ResetHeartBeatsMissed() {
+	c.heartBeatsMutex.Lock()
+	c.heartBeatsMissed = 0
+	c.heartBeatsMutex.Unlock()
+}
+
+func (c *Client) IncrementHeartBeatsMissed() {
+	c.heartBeatsMutex.Lock()
+	c.heartBeatsMissed = c.heartBeatsMissed + 1
+	c.heartBeatsMutex.Unlock()
 }
 
 // Login calls the "rtm.start" Slack API and gets a bunch of information such as
@@ -143,7 +158,9 @@ func (c *Client) Start() error {
 			c.conn = conn
 		}
 
+		c.pingTicker = time.NewTicker(time.Millisecond * 5000)
 		go c.startReadFromSlackLoop()
+		go c.startPingPump()
 	} else {
 		// Bot has been disabled by the user,
 		// so we need to mark it as disabled
@@ -184,7 +201,9 @@ func (c *Client) Start() error {
 // LoginAndStarts is a simple helper function that calls login and start successively
 // so that it can be invoked in a goroutine (as is done in InitClients)
 func (c *Client) LoginAndStart() error {
-	err := c.Login()
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = 1500 * time.Millisecond
+	err := backoff.Retry(c.Login, b)
 
 	if err == nil {
 		err = c.Start()
@@ -196,6 +215,38 @@ func (c *Client) LoginAndStart() error {
 	}
 
 	return err
+}
+
+func (c *Client) startPingPump() {
+	for _ = range c.pingTicker.C {
+		m := Message{
+			Id:             c.TeamId,
+			Type:           "ping",
+			EventTimestamp: fmt.Sprintf("%d", time.Now().UnixNano()),
+		}
+
+		json, err := json.Marshal(m)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"error": err,
+			}).Error("error marshaling ping message")
+		} else {
+			c.IncrementHeartBeatsMissed()
+			if c.heartBeatsMissed >= 3 {
+				c.ResetHeartBeatsMissed()
+				c.pingTicker.Stop()
+				c.Stop()
+				break
+			}
+			c.conn.WriteMessage(websocket.TextMessage, []byte(json))
+
+			log.WithFields(log.Fields{
+				"heartbeats": c.heartBeatsMissed,
+			}).Debug("heartbeats missed")
+		}
+	}
+
+	go c.LoginAndStart()
 }
 
 // Stop closes the websocket connection to Slack's websocket servers
@@ -440,6 +491,13 @@ func (c *Client) startReadFromSlackLoop() {
 func (c *Client) handleMessage(msg *Message) {
 	switch msg.Type {
 
+	case "pong":
+		if msg.ReplyTo == c.TeamId {
+			c.ResetHeartBeatsMissed()
+			log.WithFields(log.Fields{
+				"heartbeats": c.heartBeatsMissed,
+			}).Debug("set heartbeats to zero")
+		}
 	case "message":
 		userId := msg.UserId()
 		channelId := msg.ChannelId()


### PR DESCRIPTION
Uses Slack's `ping` message type to detect if client connections are still valid and tries to reconnect with exponential backoff