### PR TITLE
Add optional botmetrics bot registration

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -11,6 +11,10 @@
 			"Rev": "b673bf363d3658506891150a6dca42059572d1b0"
 		},
 		{
+			"ImportPath": "github.com/botmetrics/go-botmetrics",
+			"Rev": "557162f23c828eeff7622681f5ac3abcb24e5ac5"
+		},
+		{
 			"ImportPath": "github.com/cenkalti/backoff",
 			"Comment": "v1.0.0",
 			"Rev": "32cd0c5b3aef12c76ed64aaf678f6c79736be7dc"

--- a/Godeps/_workspace/src/github.com/botmetrics/go-botmetrics/.travis.yml
+++ b/Godeps/_workspace/src/github.com/botmetrics/go-botmetrics/.travis.yml
@@ -1,0 +1,4 @@
+language: go
+go:
+- 1.6
+script: make test

--- a/Godeps/_workspace/src/github.com/botmetrics/go-botmetrics/Godeps/Godeps.json
+++ b/Godeps/_workspace/src/github.com/botmetrics/go-botmetrics/Godeps/Godeps.json
@@ -1,0 +1,19 @@
+{
+	"ImportPath": "github.com/botmetrics/go-botmetrics",
+	"GoVersion": "go1.6",
+	"Packages": [
+		"./..."
+	],
+	"Deps": [
+		{
+			"ImportPath": "github.com/onsi/ginkgo",
+			"Comment": "v1.2.0-11-gd94e2f4",
+			"Rev": "d94e2f4000332f62b356ecb2840c98f4218f5358"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega",
+			"Comment": "v1.0-52-ga2ab864",
+			"Rev": "a2ab8644e0b6a33df2cbe44673bd0f6ebba9abc3"
+		}
+	]
+}

--- a/Godeps/_workspace/src/github.com/botmetrics/go-botmetrics/Godeps/Readme
+++ b/Godeps/_workspace/src/github.com/botmetrics/go-botmetrics/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/Godeps/_workspace/src/github.com/botmetrics/go-botmetrics/Makefile
+++ b/Godeps/_workspace/src/github.com/botmetrics/go-botmetrics/Makefile
@@ -1,0 +1,11 @@
+NO_COLOR=\033[0m
+OK_COLOR=\033[32;01m
+ERROR_COLOR=\033[31;01m
+WARN_COLOR=\033[33;01m
+
+all: test
+
+test:
+	@script/test
+
+.PHONY: test

--- a/Godeps/_workspace/src/github.com/botmetrics/go-botmetrics/README.md
+++ b/Godeps/_workspace/src/github.com/botmetrics/go-botmetrics/README.md
@@ -1,0 +1,69 @@
+# go-botmetrics
+
+go-botmetrics is a Go client to the
+[BotMetrics](https://getbotmetrics.com) service which lets you collect
+&amp; analyze metrics for your bot.
+
+[![Build
+Status](https://travis-ci.org/botmetrics/go-botmetrics.svg?branch=master)](https://travis-ci.org/botmetrics/go-botmetrics)
+
+## Usage
+
+Log in to your [BotMetrics](https://getbotmetrics.com) account, navigate
+to "Bot Settings" and find out your Bot ID and API Key.
+
+With that, you can initialize a `BotmetricsClient`:
+
+```go
+import "github.com/botmetrics/go-botmetrics"
+
+client := botmetrics.NewBotmetricsClient("api-key", "bot-id")
+```
+
+Alternatively, you can set the following ENV variables
+
+- `ENV['BOTMETRICS_API_KEY']`
+- `ENV['BOTMETRICS_BOT_ID']`
+
+and initialize a `BotmetricsClient` with the default ENV variables:
+
+```go
+import "github.com/botmetrics/go-botmetrics"
+
+client := botmetrics.NewBotmetricsClient()
+```
+
+### `RegisterBot`
+
+With a `BotmetricsClient` instance,
+every time you create a new Slack Bot (in the OAuth2 callback),
+and assuming the bot token you received as part of the OAuth2 callback is `bot-token`,
+you can make the following call:
+
+```go
+import "github.com/botmetrics/go-botmetrics"
+
+client := botmetrics.NewBotmetricsClient("api-key", "bot-id")
+client.RegisterBot('bot-token', 0)
+```
+
+#### Retroactive Registration
+
+If you created your bot in the past, you can pass in `created_at` with
+the UNIX timestamp of when your bot was created, like so:
+
+```go
+import "github.com/botmetrics/go-botmetrics"
+
+client := botmetrics.NewBotmetricsClient("api-key", "bot-id")
+client.RegisterBot('bot-token', 1462318092)
+```
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at https://github.com/botmetrics/go-botmetrics. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+
+
+## License
+
+The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/Godeps/_workspace/src/github.com/botmetrics/go-botmetrics/botmetrics.go
+++ b/Godeps/_workspace/src/github.com/botmetrics/go-botmetrics/botmetrics.go
@@ -1,0 +1,78 @@
+package botmetrics
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type BotmetricsClient struct {
+	ApiKey string
+	BotId  string
+}
+
+var (
+	ErrClientNotConfigured = fmt.Errorf("Set the environment variables BOTMETRICS_API_KEY and BOTMETRICS_BOT_ID or call NewBotmetricsClient(\"api_key\", \"bot_id\")")
+)
+
+func NewBotmetricsClient(args ...string) (*BotmetricsClient, error) {
+	switch len(args) {
+	case 0:
+		if os.Getenv("BOTMETRICS_API_KEY") == "" || os.Getenv("BOTMETRICS_BOT_ID") == "" {
+			return nil, ErrClientNotConfigured
+		}
+
+		return &BotmetricsClient{ApiKey: os.Getenv("BOTMETRICS_API_KEY"), BotId: os.Getenv("BOTMETRICS_BOT_ID")}, nil
+
+	case 1:
+		if os.Getenv("BOTMETRICS_BOT_ID") == "" {
+			return nil, ErrClientNotConfigured
+		}
+
+		return &BotmetricsClient{ApiKey: args[0], BotId: os.Getenv("BOTMETRICS_API_ID")}, nil
+
+	case 2:
+		return &BotmetricsClient{ApiKey: args[0], BotId: args[1]}, nil
+
+	default:
+		return nil, ErrClientNotConfigured
+	}
+}
+
+func (b *BotmetricsClient) RegisterBot(token string, createdAt int64) bool {
+	params := url.Values{
+		"format":          []string{"json"},
+		"instance[token]": []string{token},
+	}
+	host := os.Getenv("BOTMETRICS_API_HOST")
+	if host == "" {
+		host = "https://www.getbotmetrics.com"
+	}
+	url := fmt.Sprintf("%s/bots/%s/instances", host, b.BotId)
+
+	if createdAt > 0 {
+		params["instance[created_at]"] = []string{strconv.Itoa(int(createdAt))}
+	}
+
+	client := &http.Client{}
+	r, _ := http.NewRequest("POST", url, strings.NewReader(params.Encode()))
+	r.Header.Add("Authorization", b.ApiKey)
+	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Length", strconv.Itoa(len(params.Encode())))
+
+	resp, err := client.Do(r)
+
+	if err != nil {
+		return false
+	} else {
+		defer resp.Body.Close()
+		if resp.StatusCode == 201 {
+			return true
+		}
+	}
+
+	return false
+}

--- a/Godeps/_workspace/src/github.com/botmetrics/go-botmetrics/botmetrics_test.go
+++ b/Godeps/_workspace/src/github.com/botmetrics/go-botmetrics/botmetrics_test.go
@@ -1,0 +1,119 @@
+package botmetrics
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	. "github.com/zerobotlabs/relax/Godeps/_workspace/src/github.com/onsi/ginkgo"
+	. "github.com/zerobotlabs/relax/Godeps/_workspace/src/github.com/onsi/gomega"
+	"github.com/zerobotlabs/relax/Godeps/_workspace/src/github.com/onsi/gomega/ghttp"
+)
+
+func TestContext(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "botmetrics")
+}
+
+var _ = Describe("botmetrics", func() {
+	Describe("NewBotmetricsClient", func() {
+		Context("with apiKey and botId", func() {
+			It("should return a client and no error", func() {
+				c, err := NewBotmetricsClient("api_key", "bot_id")
+				Expect(c.ApiKey).To(Equal("api_key"))
+				Expect(c.BotId).To(Equal("bot_id"))
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("without apiKey and botId", func() {
+			Context("without environment variables set", func() {
+				It("should return an error", func() {
+					c, err := NewBotmetricsClient()
+					Expect(c).To(BeNil())
+					Expect(err).To(Equal(ErrClientNotConfigured))
+				})
+			})
+
+			Context("with environment variables set", func() {
+				BeforeEach(func() {
+					os.Setenv("BOTMETRICS_API_KEY", "api_key")
+					os.Setenv("BOTMETRICS_BOT_ID", "bot_id")
+				})
+
+				AfterEach(func() {
+					os.Unsetenv("BOTMETRICS_API_KEY")
+					os.Unsetenv("BOTMETRICS_BOT_ID")
+				})
+
+				It("should return a client and no error", func() {
+					c, err := NewBotmetricsClient()
+					Expect(c.ApiKey).To(Equal("api_key"))
+					Expect(c.BotId).To(Equal("bot_id"))
+					Expect(err).To(BeNil())
+				})
+			})
+		})
+	})
+
+	Describe("RegisterBot", func() {
+		var server *ghttp.Server
+		var bc *BotmetricsClient
+		var err error
+
+		BeforeEach(func() {
+			server = ghttp.NewServer()
+			os.Setenv("BOTMETRICS_API_HOST", server.URL())
+			bc, err = NewBotmetricsClient("api-key", "bot-id")
+			Expect(err).To(BeNil())
+		})
+
+		AfterEach(func() {
+			server.Close()
+			os.Unsetenv("BOTMETRICS_API_HOST")
+		})
+
+		verifyRequestResponse := func(server *ghttp.Server, method, uri, token, createdAt string, responseCode int64) {
+			var verifier http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.Method).To(Equal(method))
+				Expect(r.RequestURI).To(Equal(uri))
+				err := r.ParseForm()
+				Expect(err).To(BeNil())
+				Expect(r.Header.Get("Authorization")).To(Equal("api-key"))
+				Expect(r.PostFormValue("instance[token]")).To(Equal(token))
+				Expect(r.PostFormValue("instance[created_at]")).To(Equal(createdAt))
+				Expect(r.PostFormValue("format")).To(Equal("json"))
+
+				w.WriteHeader(int(responseCode))
+			}
+
+			server.AppendHandlers(verifier)
+		}
+
+		Context("successful API request", func() {
+			Context("with token and no createdAt", func() {
+				It("should return true", func() {
+					verifyRequestResponse(server, "POST", "/bots/bot-id/instances", "bot-token", "", 201)
+					status := bc.RegisterBot("bot-token", 0)
+					Expect(status).To(BeTrue())
+				})
+			})
+
+			Context("with token and createdAt", func() {
+				It("should return true", func() {
+					verifyRequestResponse(server, "POST", "/bots/bot-id/instances", "bot-token", "123456789", 201)
+					status := bc.RegisterBot("bot-token", 123456789)
+					Expect(status).To(BeTrue())
+				})
+			})
+		})
+
+		Context("unsuccessful API request", func() {
+			It("should return true", func() {
+				verifyRequestResponse(server, "POST", "/bots/bot-id/instances", "bot-token", "", 500)
+				status := bc.RegisterBot("bot-token", 0)
+				Expect(status).To(BeFalse())
+			})
+		})
+	})
+})

--- a/Godeps/_workspace/src/github.com/botmetrics/go-botmetrics/script/test
+++ b/Godeps/_workspace/src/github.com/botmetrics/go-botmetrics/script/test
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+go test ./...

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ Binaries are available for both OS X and Linux. Untar and gunzip the
 downloaded file and move the `relax` binary to your `$PATH` to start
 using.
 
-## Don't Want to Host It Yourself?
+## Analytics for your Slackbot
 
-If you don't want to host Relax yourself, head on over to
-[https://getbotmetrics.com](https://getbotmetrics.com) which offers
-Relax hosting as well as analytics and metrics for your Slack bot. You
-will receive Relax events as JSON strings to a webhook you specify and
-also get analytics and metrics for your Slack bot.
-
+Relax now has optional [Botmetrics](https://botmetrics.com) analytics
+built in. If you want analytics for your Slack bot, set the
+`BOTMETRICS_ENABLED` environment variable to 'true', get an API key and
+a bot ID from botmetrics and set the `BOTMETRICS_API_KEY` and
+`BOTMETRICS_BOT_ID` environment variables set up and restart your Relax
+instances.
 
 ## In Production Use
 


### PR DESCRIPTION
Relax now has optional [botmetrics](https://botmetrics.com) analytics built in. If you want analytics for your Slack bot, set the `BOTMETRICS_ENABLED` environment variable to 'true', get an API key and a bot ID from botmetrics and set the `BOTMETRICS_API_KEY` and `BOTMETRICS_BOT_ID` environment variables set up.